### PR TITLE
Improve initialization of some playback subjects

### DIFF
--- a/Sources/WebView/YouTubePlayerWebView+WKScriptMessageHandler.swift
+++ b/Sources/WebView/YouTubePlayerWebView+WKScriptMessageHandler.swift
@@ -36,6 +36,16 @@ extension YouTubePlayerWebView: WKScriptMessageHandler {
                 // Play Video
                 self.play()
             }
+            // Retrieve current values to well initialize them.
+            // In case of failure nothing is set as properties are already nil.
+            player.getPlaybackRate { result in
+                guard case .success(let playbackRate) = result else { return }
+                self.playbackRateSubject.send(playbackRate)
+            }
+            player.getPlaybackState { result in
+                guard case .success(let playbackState) = result else { return }
+                self.playbackStateSubject.send(playbackState)
+            }
         case .onStateChange:
             // Verify PlaybackState is available from message body
             guard let body = message.body as? Int,


### PR DESCRIPTION
When player is initialized and then ready, it sends the `onReady` event which update player and start video if enabled, but playback rate and playback state were still nil as Youtube API does not send any event related to those properties when it is ready. So if we want to have those values before any change on those values we have to initialize them as soon as possible. At `onReady` event seems a good place to do so.