### PR TITLE
Add host view for presenting outside of a view controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ struct ContentView: View {
 ```
 > Check out the additional [`YouTubePlayerView`](https://github.com/SvenTiigi/YouTubePlayerKit/blob/main/Sources/View/YouTubePlayerView%2BInit.swift) initializer to place an overlay for a given state.
 
-When using `UIKit` or `AppKit` you can make use of the `YouTubePlayerViewController`.
+When using `UIKit` or `AppKit` you can make use of the `YouTubePlayerViewController` or `YouTubePlayerHostView`.
 
 ```swift
 import UIKit
@@ -151,7 +151,7 @@ youTubePlayer
 
 ## YouTubePlayer
 
-A `YouTubePlayer` is the central object which needs to be passed to every YouTubePlayerView or YouTubePlayerViewController in order to play a certain YouTube video and interact with the underlying YouTube iFrame API. 
+A `YouTubePlayer` is the central object which needs to be passed to every `YouTubePlayerView`, `YouTubePlayerViewController`, or `YouTubePlayerHostView` in order to play a certain YouTube video and interact with the underlying YouTube iFrame API. 
 
 Therefore, you can easily initialize a `YouTubePlayer` by using a string literal as seen in the previous examples.
 

--- a/Sources/View/YouTubePlayerHostView.swift
+++ b/Sources/View/YouTubePlayerHostView.swift
@@ -1,0 +1,72 @@
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+// MARK: - YouTubePlayerHostBaseView
+
+#if os(macOS)
+/// The YouTubePlayerBase NSView
+public class YouTubePlayerHostBaseView: NSView {}
+#else
+/// The YouTubePlayerBase UIView
+public class YouTubePlayerHostBaseView: UIView {}
+#endif
+
+/// The YouTubePlayer HostView
+public final class YouTubePlayerHostView: YouTubePlayerHostBaseView {
+    
+    // MARK: Properties
+    
+    /// The YouTubePlayerWebView
+    private let webView: YouTubePlayerWebView
+    
+    /// The YouTubePlayer
+    public var player: YouTubePlayer {
+        get {
+            self.webView.player
+        }
+        set {
+            self.webView.player = newValue
+        }
+    }
+    
+    // MARK: Initializer
+    
+    /// Creates a new instance of `YouTubePlayerHostView`
+    /// - Parameters:
+    ///   - player: The YouTubePlayer
+    public init(player: YouTubePlayer) {
+        webView = .init(player: player)
+        #if os(macOS)
+        webView.autoresizingMask = [.width, .height]
+        #else
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        #endif
+        super.init(frame: .zero)
+        
+        addSubview(webView)
+    }
+    
+    /// Creates a new instance of `YouTubePlayerHostView`
+    /// - Parameters:
+    ///   - source: The optional YouTubePlayer Source. Default value `nil`
+    ///   - configuration: The YouTubePlayer Configuration. Default value `.init()`
+    public convenience init(
+        source: YouTubePlayer.Source? = nil,
+        configuration: YouTubePlayer.Configuration = .init()
+    ) {
+        self.init(
+            player: .init(
+                source: source,
+                configuration: configuration
+            )
+        )
+    }
+    
+    /// Initializer with NSCoder always returns nil
+    required init?(coder: NSCoder) {
+        nil
+    }
+}


### PR DESCRIPTION
At Pocket, we're investigating new ways to better support YouTube videos. We've been investigating two possible solutions: the official [youtube-ios-player-helper](https://github.com/youtube/youtube-ios-player-helper) framework, or [YouTubePlayerKit](https://github.com/SvenTiigi/YouTubePlayerKit/).

We needed a way to render an appropriate view within a `UICollectionViewCell`, and while one _can_ use the preexisting `YouTubePlayerViewController`, we believe there is more overhead in doing so than adding and reusing a single view to a `UICollectionViewCell`. The other alternative, `YouTubePlayerView`, was not a viable option for us as it required SwiftUI, which we were not using within the context of YouTube support.

Ultimately, we forked the project and added a new class, `YouTubePlayerHostView`, which "hosts" (i.e contains, and hence the name) the underlying `YouTubePlayerWebView` within a `UIView` or `NSView`, depending on your platform, just as we see in both the custom view controller and SwiftUI views.

Usage is similar to that of the view controller as to respect the nature and convenience of its support:

```swift
// Initialize a YouTubePlayerHostView
let youTubePlayerHostView = YouTubePlayerHostView(
    player: "https://youtube.com/watch?v=psL_5RIBqnY"
)

// Example: Access the underlying iFrame API via the `YouTubePlayer` instance
youTubePlayerHostView.player.showStatsForNerds()

// Present YouTubePlayerHostView
addSubview(youTubePlayerHostView)

```

I've done my best to respect the current patterns defined by the project, including that of documentation.

Looking forward to discuss this pull request with you!