### PR TITLE
Custom user agent added

### DIFF
--- a/Sources/Configuration/YouTubePlayer+Configuration.swift
+++ b/Sources/Configuration/YouTubePlayer+Configuration.swift
@@ -89,6 +89,9 @@ public extension YouTubePlayer {
         /// This value is used in YouTube Analytics reporting when the YouTube player is embedded
         public var referrer: String?
         
+        /// This parameter lets you set a custom user agent to pass to the WKWebView
+        public var customUserAgent: String?
+        
         // MARK: Initializer
         
         /// Creates a new instance of `YouTubePlayer.Configuration`
@@ -111,7 +114,8 @@ public extension YouTubePlayer {
             playInline: Bool? = nil,
             showRelatedVideos: Bool? = nil,
             startTime: Int? = nil,
-            referrer: String? = nil
+            referrer: String? = nil,
+            customUserAgent: String? = nil
         ) {
             self.isUserInteractionEnabled = isUserInteractionEnabled
             self.allowsPictureInPictureMediaPlayback = allowsPictureInPictureMediaPlayback
@@ -132,6 +136,7 @@ public extension YouTubePlayer {
             self.showRelatedVideos = showRelatedVideos
             self.startTime = startTime
             self.referrer = referrer
+            self.customUserAgent = customUserAgent
         }
         
     }

--- a/Sources/WebView/YouTubePlayerWebView+LoadPlayer.swift
+++ b/Sources/WebView/YouTubePlayerWebView+LoadPlayer.swift
@@ -57,6 +57,7 @@ extension YouTubePlayerWebView {
             .configuration
             .allowsPictureInPictureMediaPlayback ?? true
         #endif
+        self.customUserAgent = self.player.configuration.customUserAgent
         // Load HTML string
         self.loadHTMLString(
             youTubePlayerHTML.contents,


### PR DESCRIPTION
I would like to be able to add a custom user agent string to the YouTubePlayer configuration. When using the YouTube iframe player on iPad or Mac the full screen button stops working. One easy way I have found to get it working is to override the user agent string passed by the web view.