### PR TITLE
Added optional frameObserverDelay to config

### DIFF
--- a/Sources/Configuration/YouTubePlayer+Configuration.swift
+++ b/Sources/Configuration/YouTubePlayer+Configuration.swift
@@ -92,6 +92,10 @@ public extension YouTubePlayer {
         /// An optional custom user agent of the underlying web view
         public var customUserAgent: String?
         
+        /// This parameter controls the amount of delay used when resizing the web player after a frame change
+        /// A delay is needed to ensure that the underlying window of the WKWebView has resized
+        public var frameObserverDelay: Double?
+
         // MARK: Initializer
         
         /// Creates a new instance of `YouTubePlayer.Configuration`
@@ -115,7 +119,8 @@ public extension YouTubePlayer {
             showRelatedVideos: Bool? = nil,
             startTime: Int? = nil,
             referrer: String? = nil,
-            customUserAgent: String? = nil
+            customUserAgent: String? = nil,
+            frameObserverDelay: Double? = nil
         ) {
             self.isUserInteractionEnabled = isUserInteractionEnabled
             self.allowsPictureInPictureMediaPlayback = allowsPictureInPictureMediaPlayback
@@ -137,6 +142,7 @@ public extension YouTubePlayer {
             self.startTime = startTime
             self.referrer = referrer
             self.customUserAgent = customUserAgent
+            self.frameObserverDelay = frameObserverDelay
         }
         
     }

--- a/Sources/Configuration/YouTubePlayer+Configuration.swift
+++ b/Sources/Configuration/YouTubePlayer+Configuration.swift
@@ -91,10 +91,6 @@ public extension YouTubePlayer {
         
         /// An optional custom user agent of the underlying web view
         public var customUserAgent: String?
-        
-        /// This parameter controls the amount of delay used when resizing the web player after a frame change
-        /// A delay is needed to ensure that the underlying window of the WKWebView has resized
-        public var frameObserverDelay: Double?
 
         // MARK: Initializer
         
@@ -119,8 +115,7 @@ public extension YouTubePlayer {
             showRelatedVideos: Bool? = nil,
             startTime: Int? = nil,
             referrer: String? = nil,
-            customUserAgent: String? = nil,
-            frameObserverDelay: Double? = nil
+            customUserAgent: String? = nil
         ) {
             self.isUserInteractionEnabled = isUserInteractionEnabled
             self.allowsPictureInPictureMediaPlayback = allowsPictureInPictureMediaPlayback
@@ -142,7 +137,6 @@ public extension YouTubePlayer {
             self.startTime = startTime
             self.referrer = referrer
             self.customUserAgent = customUserAgent
-            self.frameObserverDelay = frameObserverDelay
         }
         
     }

--- a/Sources/Resources/YouTubePlayer.html
+++ b/Sources/Resources/YouTubePlayer.html
@@ -59,24 +59,19 @@
             // Send onIframeAPIReady event
             sendYouTubePlayerEvent('onIframeAPIReady');
         });
-
-        // On window resize
-        window.onresize = () => {
-            // Adjust YouTubePlayer Size
-            adjustYouTubePlayerSize();
-        }
         
         // Adjust YouTubePlayer Size
-        function adjustYouTubePlayerSize() {
+        function adjustYouTubePlayerWithSize(width, height) {
             // Check if YouTubePlayer is unavailable
             if (!player) {
                 // Return out of function
                 return;
             }
+            
             // Set Player size
             player.setSize(
-                window.innerWidth,
-                window.innerHeight
+                width,
+                height
             );
         }
         

--- a/Sources/WebView/YouTubePlayerWebView.swift
+++ b/Sources/WebView/YouTubePlayerWebView.swift
@@ -84,7 +84,7 @@ private extension YouTubePlayerWebView {
             // the underlying window of the WKWebView
             // has resized properly
             .delay(
-                for: 0.1,
+                for: .seconds(self.player.configuration.frameObserverDelay ?? 0.1),
                 scheduler: DispatchQueue.main
             )
             .sink { [weak self] _ in

--- a/Sources/WebView/YouTubePlayerWebView.swift
+++ b/Sources/WebView/YouTubePlayerWebView.swift
@@ -80,17 +80,10 @@ private extension YouTubePlayerWebView {
         // Setup frame observation
         self.frameObservation = self
             .publisher(for: \.frame)
-            // Add a slight delay to ensure
-            // the underlying window of the WKWebView
-            // has resized properly
-            .delay(
-                for: .seconds(self.player.configuration.frameObserverDelay ?? 0.1),
-                scheduler: DispatchQueue.main
-            )
-            .sink { [weak self] _ in
+            .sink { [weak self] frame in
                 // Adjust YouTubePlayer Size
                 self?.evaluate(
-                    javaScript: "adjustYouTubePlayerSize()"
+                    javaScript: "adjustYouTubePlayerWithSize(\(frame.width), \(frame.height))"
                 )
             }
         // Set YouTubePlayerAPI on current Player


### PR DESCRIPTION
I have to do a good bit of resizing and moving of the YouTube player within my app and have noticed that sometimes I get left with an incorrectly sized player. The player container has resized it's frame correctly but the underlying web player ends up using only a fraction of the available space. It happens only sometimes but when it happens it looks pretty bad.

I've discovered that this happens because of the way the YouTubePlayerWebView calls adjustYouTubePlayerSize() on frame changes. There's a delay of 0.1 seconds put in to give the WKWebView time for it's window to be resized. This delay is probably fine for most scenarios but I've found I need to increase it a bit. 

I'd propose leaving the default delay as it was and letting the user change it in the config if required