### PR TITLE
Fix auto resizing

### DIFF
--- a/Sources/Resources/YouTubePlayer.html
+++ b/Sources/Resources/YouTubePlayer.html
@@ -52,14 +52,15 @@
                 %@
             );
             // Set initial size
-            player.setSize(
-                window.innerWidth,
-                window.innerHeight
-            );
+            setYouTubePlayerSize();
             // Send onIframeAPIReady event
             sendYouTubePlayerEvent('onIframeAPIReady');
         });
-        
+
+        window.onresize = () => {
+            setYouTubePlayerSize();
+        }
+
         // Set YouTubePlayer Size
         function setYouTubePlayerSize(width, height) {
             // Check if YouTubePlayer is unavailable
@@ -73,7 +74,7 @@
                 height
             );
         }
-        
+
         // Send YouTubePlayer Event with optional data
         function sendYouTubePlayerEvent(event, data) {
             var locationHref = 'youtubeplayer://' + event;


### PR DESCRIPTION
Since the [release 1.1.9](https://github.com/SvenTiigi/YouTubePlayerKit/releases/tag/1.1.9) the issue #10 which was fixed in [release 1.1.4](https://github.com/SvenTiigi/YouTubePlayerKit/releases/tag/1.1.4) is now broken due to the commit 4ad4b6312344ab5716178c5c5971637f02022e01 by @lorcanotoole because he deleted `window.onresize`.

This PR fix this issue.