### PR TITLE
Exposed closing full screen video player method from WKWebView

### DIFF
--- a/Sources/YouTubePlayer+API.swift
+++ b/Sources/YouTubePlayer+API.swift
@@ -273,7 +273,14 @@ extension YouTubePlayer: YouTubePlayerVideoAPI {
             javaScript: .player("seekTo(\(seconds), \(String(allowSeekAhead)))")
         )
     }
-    
+
+    /// Closes all media presentations(Full screen/Picture in Picture) of the current video
+    @available(iOS 15.0, *)
+    public func closeAllMediaPresentations() {
+        Task { @MainActor in
+            await self.webView.closeAllMediaPresentations()
+        }
+    }
 }
 
 // MARK: - YouTubePlayer360DegreePerspectiveAPI


### PR DESCRIPTION
Firstly, Thank you for this library. 😄 

I have a use case where I would like to exit the video from fullscreen programmatically. I researched and found a possible solution. Please take a look.

Note: I am new to the latest Swift features, and every improvement suggestion is welcomed.