### PR TITLE
Exposed closing full screen video player method from WKWebView

### DIFF
--- a/Sources/API/YouTubePlayer+VideoAPI.swift
+++ b/Sources/API/YouTubePlayer+VideoAPI.swift
@@ -40,5 +40,12 @@ public extension YouTubePlayer {
             )
         )
     }
-    
+
+    /// Closes all media presentations(Full screen/Picture in Picture) of the current video
+    @available(iOS 15.0 , macOS 12.0, *)
+    func closeAllMediaPresentations() {
+        Task { @MainActor in
+            await self.webView.closeAllMediaPresentations()
+        }
+    }
 }


### PR DESCRIPTION
Firstly, Thank you for this library. 😄

I have a use case where I would like to exit the video from fullscreen programmatically. I researched and found a possible solution. Please take a look.

Note: I am new to the latest Swift features, and every improvement suggestion is welcomed.