### PR TITLE
Making WebView Public

### DIFF
--- a/Sources/YouTubePlayer.swift
+++ b/Sources/YouTubePlayer.swift
@@ -53,7 +53,7 @@ public final class YouTubePlayer: ObservableObject {
     private(set) lazy var playbackRateSubject = CurrentValueSubject<PlaybackRate?, Never>(nil)
     
     /// The YouTubePlayer WebView
-    private(set) lazy var webView: YouTubePlayerWebView = {
+    public private(set) lazy var webView: YouTubePlayerWebView = {
         // Initialize a YouTubePlayerWebView
         let webView = YouTubePlayerWebView(player: self)
         // Subscribe to YouTubePlayerWebView Event Subject


### PR DESCRIPTION
Having the WebView be public is useful in certain cases such as when you need to access its layer directly when integrating with other frameworks like SceneKit, ARKit, etc.