### PR TITLE
Added additional PlaybackQuality value that occurs for some videos

### DIFF
--- a/Sources/Models/YouTubePlayer+PlaybackQuality.swift
+++ b/Sources/Models/YouTubePlayer+PlaybackQuality.swift
@@ -20,6 +20,8 @@ public extension YouTubePlayer {
         case hd1080
         /// High resolution
         case highResolution = "highres"
+        // Unknown
+        case unknown
     }
     
 }


### PR DESCRIPTION
I used `player.getInformation()` to fetch video duration but that request failed because it couldn't parse the response for some videos. It seems that video playback quality enum doesn't cover all the cases.

<details>
```
### APIError(javaScript: "player.playerInfo;", javaScriptResponse: Optional(["availableQualityLevels": <__NSArrayM 0x600000c9b570>(

)
, "debugText": {
  "debug_videoId": "HxJg9heoso4",
  "debug_playbackQuality": "unknown",
  "debug_date": "Tue Jan 09 2024 10:24:04 GMT+0100 (Central European Standard Time)",
  "timestamp": 1704792244548
}, "muted": 0, "videoBytesTotal": 1, "currentTime": 0, "currentTimeLastUpdated_": 1704792244.549, "playbackRate": 1, "playlistId": <null>, "volume": 100, "mediaReferenceTime": 0, "videoData": {
    allowLiveDvr = 0;
    author = "";
    backgroundable = 0;
    cpn = BrtewYBuFWp3bbRX;
    errorCode = "<null>";
    hasProgressBarBoundaries = 0;
    isListed = 0;
    isLive = 0;
    isManifestless = 0;
    isMultiChannelAudio = 0;
    isPlayable = 1;
    isPremiere = 0;
    isWindowedLive = 0;
    paidContentOverlayDurationMs = 0;
    progressBarEndPositionUtcTimeMillis = "<null>";
    progressBarStartPositionUtcTimeMillis = "<null>";
    title = "Wilfa Svart Precision, verdens beste kaffetrakter.";
    "video_id" = HxJg9heoso4;
}, "options": <__NSArrayM 0x600000c9b480>(

)
, "videoBytesLoaded": 0, "videoStartBytes": 0, "option": <null>, "availablePlaybackRates": <__NSArrayM 0x600000c9b5d0>(
0.25,
0.5,
0.75,
1,
1.25,
1.5,
1.75,
2
)
, "videoInfoVisible": 0, "playbackQuality": unknown, "videoUrl": https://www.youtube.com/watch?v=HxJg9heoso4, "playlistIndex": -1, "playlist": <null>, "sphericalProperties": {
}, "size": {
    height = 192;
    width = 353;
}, "playerMode": {
}, "apiInterface": <__NSArrayM 0x600000c9aa30>(
cueVideoById,
loadVideoById,
cueVideoByUrl,
loadVideoByUrl,
playVideo,
pauseVideo,
stopVideo,
clearVideo,
getVideoBytesLoaded,
getVideoBytesTotal,
getVideoLoadedFraction,
getVideoStartBytes,
cuePlaylist,
loadPlaylist,
nextVideo,
previousVideo,
playVideoAt,
setShuffle,
setLoop,
getPlaylist,
getPlaylistIndex,
getPlaylistId,
loadModule,
unloadModule,
setOption,
getOption,
getOptions,
mute,
unMute,
isMuted,
setVolume,
getVolume,
seekTo,
getPlayerMode,
getPlayerState,
getAvailablePlaybackRates,
getPlaybackQuality,
setPlaybackQuality,
getAvailableQualityLevels,
getCurrentTime,
getDuration,
addEventListener,
removeEventListener,
getDebugText,
getVideoData,
addCueRange,
removeCueRange,
setSize,
getApiInterface,
destroy,
mutedAutoplay,
getVideoEmbedCode,
getVideoUrl,
getMediaReferenceTime,
getSize,
setFauxFullscreen,
logImaAdEvent,
preloadVideoById,
showVideoInfo,
hideVideoInfo,
isVideoInfoVisible,
getPlaybackRate,
setPlaybackRate,
getSphericalProperties,
setSphericalProperties
)
, "playerState": 5, "videoLoadedFraction": 0, "videoEmbedCode": <iframe width="353" height="192" src="https://www.youtube.com/embed/HxJg9heoso4" title="Wilfa Svart Precision, verdens beste kaffetrakter." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>, "duration": 101]), underlyingError: Optional(Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "playbackQuality", intValue: nil)], debugDescription: "Cannot initialize PlaybackQuality from invalid String value unknown", underlyingError: nil))), reason: Optional("Decoding failed: dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: \"playbackQuality\", intValue: nil)], debugDescription: \"Cannot initialize PlaybackQuality from invalid String value unknown\", underlyingError: nil))"))
### APIError(javaScript: "player.playerInfo;", javaScriptResponse: Optional(["availableQualityLevels": <__NSArrayM 0x600000c9b030>(

)
, "debugText": {
  "debug_videoId": "JQ2-C5rtTzo",
  "debug_playbackQuality": "unknown",
  "debug_date": "Tue Jan 09 2024 10:24:04 GMT+0100 (Central European Standard Time)",
  "timestamp": 1704792244545
}, "muted": 0, "videoBytesTotal": 1, "currentTime": 0, "currentTimeLastUpdated_": 1704792244.546, "playbackRate": 1, "playlistId": <null>, "volume": 100, "mediaReferenceTime": 0, "videoData": {
    allowLiveDvr = 0;
    author = "";
    backgroundable = 0;
    cpn = bizgdXb4E1PfTIkd;
    errorCode = "<null>";
    hasProgressBarBoundaries = 0;
    isListed = 0;
    isLive = 0;
    isManifestless = 0;
    isMultiChannelAudio = 0;
    isPlayable = 1;
    isPremiere = 0;
    isWindowedLive = 0;
    paidContentOverlayDurationMs = 0;
    progressBarEndPositionUtcTimeMillis = "<null>";
    progressBarStartPositionUtcTimeMillis = "<null>";
    title = "Innobot Robotst\U00f8vsuger";
    "video_id" = "JQ2-C5rtTzo";
}, "options": <__NSArrayM 0x600000c9afd0>(

)
, "videoBytesLoaded": 0, "videoStartBytes": 0, "option": <null>, "availablePlaybackRates": <__NSArrayM 0x600000c9a820>(
0.25,
0.5,
0.75,
1,
1.25,
1.5,
1.75,
2
)
, "videoInfoVisible": 0, "playbackQuality": unknown, "videoUrl": https://www.youtube.com/watch?v=JQ2-C5rtTzo, "playlistIndex": -1, "playlist": <null>, "sphericalProperties": {
}, "size": {
    height = 192;
    width = 353;
}, "playerMode": {
}, "apiInterface": <__NSArrayM 0x600000c9a070>(
cueVideoById,
loadVideoById,
cueVideoByUrl,
loadVideoByUrl,
playVideo,
pauseVideo,
stopVideo,
clearVideo,
getVideoBytesLoaded,
getVideoBytesTotal,
getVideoLoadedFraction,
getVideoStartBytes,
cuePlaylist,
loadPlaylist,
nextVideo,
previousVideo,
playVideoAt,
setShuffle,
setLoop,
getPlaylist,
getPlaylistIndex,
getPlaylistId,
loadModule,
unloadModule,
setOption,
getOption,
getOptions,
mute,
unMute,
isMuted,
setVolume,
getVolume,
seekTo,
getPlayerMode,
getPlayerState,
getAvailablePlaybackRates,
getPlaybackQuality,
setPlaybackQuality,
getAvailableQualityLevels,
getCurrentTime,
getDuration,
addEventListener,
removeEventListener,
getDebugText,
getVideoData,
addCueRange,
removeCueRange,
setSize,
getApiInterface,
destroy,
mutedAutoplay,
getVideoEmbedCode,
getVideoUrl,
getMediaReferenceTime,
getSize,
setFauxFullscreen,
logImaAdEvent,
preloadVideoById,
showVideoInfo,
hideVideoInfo,
isVideoInfoVisible,
getPlaybackRate,
setPlaybackRate,
getSphericalProperties,
setSphericalProperties
)
, "playerState": 5, "videoLoadedFraction": 0, "videoEmbedCode": <iframe width="353" height="192" src="https://www.youtube.com/embed/JQ2-C5rtTzo" title="Innobot Robotstøvsuger" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>, "duration": 75]), underlyingError: Optional(Swift.DecodingError.dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "playbackQuality", intValue: nil)], debugDescription: "Cannot initialize PlaybackQuality from invalid String value unknown", underlyingError: nil))), reason: Optional("Decoding failed: dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: \"playbackQuality\", intValue: nil)], debugDescription: \"Cannot initialize PlaybackQuality from invalid String value unknown\", underlyingError: nil))"))
```
</details>