### PR TITLE
Prevent JavaScript evaluation from always throwing a WKErrorDomain error

### DIFF
--- a/Sources/WebView/YouTubePlayerWebView+Evaluate.swift
+++ b/Sources/WebView/YouTubePlayerWebView+Evaluate.swift
@@ -86,7 +86,16 @@ extension YouTubePlayerWebView {
         let evaluateJavaScript = { [weak self] in
             // Evaluate JavaScript
             self?.evaluateJavaScript(
-                javaScript.rawValue
+              // Wrap JavaScript with no-op function to address
+              // JavaScript execution returning an error involving
+              // a result of an unsupported type, based off
+              // solution from the following URL:
+              //   - https://stackoverflow.com/a/75657727
+              """
+              (function() {
+                  \(javaScript.rawValue);
+              })();
+              """
             ) { javaScriptResponse, error in
                 // Initialize Result
                 let result: Result<Response, YouTubePlayer.APIError> = {


### PR DESCRIPTION
While debugging some issues, I noticed that I kept getting an issue like this anytime JavaScript code was being evaluated in the web view subclass:
```
"Error Domain=WKErrorDomain Code=5 "JavaScript execution returned a result of an unsupported type" UserInfo={NSLocalizedDescription=JavaScript execution returned a result of an unsupported type}" 
```

Wrapping it in a no-op function seems to fix the problem.