### PR TITLE
Reload webView after calling YouTubePlayer's load and cue functions

### DIFF
--- a/Sources/API/YouTubePlayer+QueueingAPI.swift
+++ b/Sources/API/YouTubePlayer+QueueingAPI.swift
@@ -18,6 +18,7 @@ public extension YouTubePlayer {
             completion?(.success(()))
             return
         }
+        let reloadWebView = source != self.source
         // Update Source
         self.update(
             source: source,
@@ -31,6 +32,11 @@ public extension YouTubePlayer {
             }(),
             completion: completion
         )
+        // Ensure publishers send events downstream after
+        // updating source
+        if reloadWebView {
+            reload()
+        }
     }
     
     #if compiler(>=5.5) && canImport(_Concurrency)
@@ -62,6 +68,7 @@ public extension YouTubePlayer {
             completion?(.success(()))
             return
         }
+        let reloadWebView = source != self.source
         // Update Source
         self.update(
             source: source,
@@ -75,6 +82,11 @@ public extension YouTubePlayer {
             }(),
             completion: completion
         )
+        // Ensure publishers send events downstream after
+        // updating source
+        if reloadWebView {
+            reload()
+        }
     }
     
     #if compiler(>=5.5) && canImport(_Concurrency)


### PR DESCRIPTION
Right now YouTubePlayer's `statePublisher` only sends its state downstream during the initial instance when YouTubePlayer's source is set. However, this does not ever happen again if `load` or `cue` is called with a new `YouTubePlayer.Source` value, making the `statePublisher` property unusable in its current state (no pun intended!).