### PR TITLE
make originURL an parameter

### DIFF
--- a/Sources/Configuration/YouTubePlayer+Configuration.swift
+++ b/Sources/Configuration/YouTubePlayer+Configuration.swift
@@ -8,6 +8,12 @@ public extension YouTubePlayer {
     /// - Read more: https://developers.google.com/youtube/player_parameters
     struct Configuration: Hashable {
         
+        public static var defaultOriginURL: URL? = Bundle
+            .main
+            .bundleIdentifier
+            .flatMap { ["https://", $0.lowercased()].joined() }
+            .flatMap(URL.init)
+
         // MARK: Properties
         
         /// A Boolean value indicating if safe area insets should be added automatically to content insets
@@ -105,6 +111,9 @@ public extension YouTubePlayer {
         /// An optional custom user agent of the underlying web view
         public var customUserAgent: String?
 
+        /// The origin URL
+        public var originURL: URL?
+        
         // MARK: Initializer
         
         /// Creates a new instance of `YouTubePlayer.Configuration`
@@ -131,7 +140,8 @@ public extension YouTubePlayer {
             showRelatedVideos: Bool? = nil,
             startTime: Int? = nil,
             referrer: String? = nil,
-            customUserAgent: String? = nil
+            customUserAgent: String? = nil,
+            originURL: URL? = Configuration.defaultOriginURL
         ) {
             self.automaticallyAdjustsContentInsets = automaticallyAdjustsContentInsets
             self.allowsPictureInPictureMediaPlayback = allowsPictureInPictureMediaPlayback
@@ -156,6 +166,7 @@ public extension YouTubePlayer {
             self.startTime = startTime
             self.referrer = referrer
             self.customUserAgent = customUserAgent
+            self.originURL = originURL
         }
         
     }

--- a/Sources/WebView/YouTubePlayerWebView.swift
+++ b/Sources/WebView/YouTubePlayerWebView.swift
@@ -12,12 +12,6 @@ final class YouTubePlayerWebView: WKWebView {
     /// The YouTubePlayer
     private(set) weak var player: YouTubePlayer?
     
-    /// The origin URL
-    private(set) lazy var originURL: URL? = Bundle
-        .main
-        .bundleIdentifier
-        .flatMap { ["https://", $0.lowercased()].joined() }
-        .flatMap(URL.init)
     
     /// The YouTubePlayerWebView Event PassthroughSubject
     private(set) lazy var eventSubject = PassthroughSubject<Event, Never>()
@@ -43,6 +37,7 @@ final class YouTubePlayerWebView: WKWebView {
             configuration: {
                 // Initialize WebView Configuration
                 let configuration = WKWebViewConfiguration()
+                
                 #if !os(macOS)
                 // Allows inline media playback
                 configuration.allowsInlineMediaPlayback = true
@@ -175,7 +170,7 @@ extension YouTubePlayerWebView {
                 options: .init(
                     playerSource: player.source,
                     playerConfiguration: player.configuration,
-                    originURL: self.originURL
+                    originURL: player.configuration.originURL
                 )
             )
         } catch {
@@ -217,7 +212,7 @@ extension YouTubePlayerWebView {
         // Load HTML string
         self.loadHTMLString(
             youTubePlayerHTML.contents,
-            baseURL: self.originURL
+            baseURL: player.configuration.originURL
         )
         // Return success
         return true


### PR DESCRIPTION
Background:
This MR addresses an issue where YouTube requires login for video playback from certain IPs, displaying a "Sign in to confirm that you're not a bot" message. By setting the origin parameter to nil or something else, it can bypass this login requirement and allow videos to play normally.

The Change:
make it an parameter. its default value is same as before.