### PR TITLE
Add explicit UIKit/AppKit imports for Library Evolution support

### DIFF
--- a/Sources/API/YouTubePlayer+VideoThumbnailAPI.swift
+++ b/Sources/API/YouTubePlayer+VideoThumbnailAPI.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
 // MARK: - Video Thumbnail API
 
 public extension YouTubePlayer {


### PR DESCRIPTION
To allow YouTubePlayerKit to be used part of the xcframework and hen 
`BUILD_LIBRARY_FOR_DISTRIBUTION=YES` is set.