### PR TITLE
Library Evolution Support

### DIFF
--- a/Sources/API/YouTubePlayer+VideoThumbnailAPI.swift
+++ b/Sources/API/YouTubePlayer+VideoThumbnailAPI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 // MARK: - Video Thumbnail API
 


### PR DESCRIPTION
To allow YouTubePlayerKit to be used part of the xcframework and when
BUILD_LIBRARY_FOR_DISTRIBUTION=YES is set.