### PR TITLE
Fix memory leak on frame observer

### DIFF
--- a/Sources/WebView/YouTubePlayerWebView.swift
+++ b/Sources/WebView/YouTubePlayerWebView.swift
@@ -132,9 +132,9 @@ private extension YouTubePlayerWebView {
         .map(\.size)
         .filter { $0 != .zero }
         .removeDuplicates()
-        .sink { size in
+        .sink { [weak self] size in
             // Set player size
-            Task(priority: .userInitiated) { [weak self] in
+            Task(priority: .userInitiated) {
                 try? await self?.evaluate(
                     javaScript: .youTubePlayer(
                         functionName: "setSize",


### PR DESCRIPTION
Hi there 👋

This PR addresses a memory leak (see #37 [and maybe #131]) caused by a strong capture of `YouTubePlayerWebView` inside its `frameChangesCancellable`. Weakifying `self` inside the `Task` had no effect, since the view was already strongly captured by the `sink`, preventing proper deallocation of the `NSKVOObserver` and `WebView` itself.

In practice, this will cause the player to leak and, if the player is closed before the video starts, audio might continue playing in the background with no way to stop it.

This change weakens the self capture in sink to ensure proper cleanup.
