### PR TITLE
Expose subjects as public while retaining read-only

### DIFF
--- a/Sources/YouTubePlayer.swift
+++ b/Sources/YouTubePlayer.swift
@@ -59,10 +59,10 @@ public final class YouTubePlayer: ObservableObject {
     }
     
     /// The state subject.
-    private(set) lazy var stateSubject = CurrentValueSubject<State, Never>(.idle)
+    public private(set) lazy var stateSubject = CurrentValueSubject<State, Never>(.idle)
     
     /// The playback state subject.
-    private(set) lazy var playbackStateSubject = CurrentValueSubject<PlaybackState?, Never>(nil)
+    public private(set) lazy var playbackStateSubject = CurrentValueSubject<PlaybackState?, Never>(nil)
     
     /// The YouTube player web view.
     private(set) lazy var webView: YouTubePlayerWebView = {


### PR DESCRIPTION
Trying to fix the following issue
``'playbackStateSubject' is inaccessible due to 'internal' protection level
``

Trying to receive the playback state change and it seems it is designed to be accessible to the outside as read-only. 

Verified this allows access from outside via

```
.onReceive(youTubePlayer.playbackStateSubject) { newState in
  // Track when video starts playing (state changes to playing)
  if newState == .playing && !hasTrackedPlay {
    hasTrackedPlay = true
```
